### PR TITLE
import setuptools in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,8 @@ if os.name in ('nt', 'dos'):
 
 # At least we're on the python version we need, move on.
 
-from distutils.core import setup
+# from distutils.core import setup
+from setuptools import setup
 
 pjoin = os.path.join
 here = os.path.abspath(os.path.dirname(__file__))


### PR DESCRIPTION
Switch to setup tools to build wheels, to deploy on production machines where no build tools are installed (and no internet access).